### PR TITLE
Add onboarding documentation for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-- 👋 Hi, I’m @amia-mirabel
-- 👀 I’m interested in ...
-- 🌱 I’m currently learning ...
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
+# Amia-Mirabel Repository
 
-<!---
-amia-mirabel/amia-mirabel is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+Welcome! This repository currently serves as the profile page for the amia-mirabel account. It is intentionally minimal while we prepare the initial project scaffold.
+
+## Current Structure
+
+- `README.md` – Provides a quick introduction for visitors and teammates.
+- `docs/ONBOARDING.md` – Onboarding guide for new contributors with the planned repository layout and next steps.
+
+## Next Steps
+
+If you are joining the project, start by reading `docs/ONBOARDING.md` for context on the roadmap, coding standards to establish, and the checklist for setting up the initial code structure.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,42 @@
+# Amia-Mirabel Codebase Onboarding Guide
+
+Welcome to the Amia-Mirabel repository! This document captures the current state of the codebase and how we expect it to evolve so that you can get productive quickly.
+
+## Repository Overview
+
+At the moment this repository only contains a top-level `README.md`. This is the profile README that GitHub renders on the amia-mirabel account page. No application source code has been committed yet, so the repo is an ideal blank slate for setting up conventions and scaffolding.
+
+The following high-level structure is planned:
+
+```
+.
+├── docs/                  # Reference and onboarding material
+├── src/                   # Application source code (to be added)
+├── tests/                 # Automated tests (to be added)
+├── .github/               # Workflows and issue templates (optional)
+└── README.md              # Profile/landing page content
+```
+
+As new code is added we will populate the `src/` and `tests/` directories following language-specific best practices.
+
+## Current Priorities
+
+1. **Establish coding standards** – Decide on the primary programming language, formatting rules, and linting tools before committing application code.
+2. **Define project goals** – Clarify the scope of the project so directory structure and dependencies can be planned appropriately.
+3. **Set up CI/CD early** – Even a simple automated test or lint workflow helps enforce quality from the first lines of code.
+
+## Getting Started Checklist
+
+- [ ] Align with the team on the initial feature or proof-of-concept to build.
+- [ ] Create the corresponding project structure under `src/` and `tests/`.
+- [ ] Add linting/formatting configuration (e.g., ESLint + Prettier for JavaScript, Ruff + Black for Python).
+- [ ] Introduce a basic CI workflow under `.github/workflows/` once tests are available.
+
+## Suggested Next Steps for You
+
+1. Review the `README.md` to understand how the profile page is currently presented.
+2. Draft a proposal for the first module or feature we plan to implement.
+3. Prepare a minimal project scaffold (language runtime, package manager files, initial entry point) and open a PR for team review.
+4. Collaborate with the team on documenting conventions in this `docs/` directory as the codebase grows.
+
+Welcome aboard, and feel free to expand this guide with any insights you gather!


### PR DESCRIPTION
## Summary
- replace the placeholder profile README with a concise description of the repository
- add an onboarding guide outlining the planned project structure and immediate setup priorities

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68da67681ac8832db1511aa47f991b48