### PR TITLE
Add markdownlint configuration and workflow

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,26 @@
+name: Markdown lint
+
+on:
+  push:
+    paths:
+      - README.md
+      - .markdownlint.json
+      - .github/workflows/markdownlint.yml
+  pull_request:
+    paths:
+      - README.md
+      - .markdownlint.json
+      - .github/workflows/markdownlint.yml
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install markdownlint-cli
+        run: npm install --global markdownlint-cli@0.37.0
+      - name: Run markdownlint
+        run: markdownlint README.md

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD041": false
+}

--- a/README.md
+++ b/README.md
@@ -5,9 +5,19 @@
 - 📫 How to reach me ...
 - 😄 Pronouns: ...
 - ⚡ Fun fact: ...
-
 <!---
 amia-mirabel/amia-mirabel is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
 
+## Markdown linting
+
+This repository uses [markdownlint](https://github.com/DavidAnson/markdownlint) with the configuration in `.markdownlint.json`.
+
+Run the lint check locally with:
+
+```bash
+npx markdownlint-cli@0.37.0 README.md
+```
+
+The command requires Node.js and automatically downloads the CLI without needing a global installation.


### PR DESCRIPTION
## Summary
- add a markdownlint configuration for the repository README
- add a GitHub Actions workflow to lint README.md with markdownlint
- document how to run the markdown lint check locally

## Testing
- n/a (network restrictions prevented running `npx markdownlint-cli@0.37.0 README.md`)


------
https://chatgpt.com/codex/tasks/task_b_68f1dce08290832da7489e6b142bcf73